### PR TITLE
gitignoreファイル編集

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 /config/master.key
 
 public/uploads/*
+pablic/uploads/message/image/!dummy.png

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@
 /config/master.key
 
 public/uploads/*
-pablic/uploads/message/image/!dummy.png
+public/uploads/message/image/!dummy.png


### PR DESCRIPTION
# WHAT
 - gitignore編集。publicフォルダ内のdummy.pngファイルに関しては無視しない設定にした。

# WHY
 - デプロイした際にファイルを見つけることができなくなる為。