### PR TITLE
edit_view

### DIFF
--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -9,7 +9,8 @@
         %ul.main-header__left-box__member-list
           Member：
           %li.main-header__left-box__member-list__member-name
-          = current_user.name
+          - @group.users.each do |user|
+            = user.name
       = link_to edit_group_path(current_user.group_ids) do
         .main-header__edit-btn Edit
 


### PR DESCRIPTION
# WHAT
 - グループメンバー全員の名前をビューに表示出来るようにした

# WHY 
 - グループメンバーに誰がいるか把握できない為